### PR TITLE
[3차 세미나 과제] 필수 과제 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+.yml
+*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'mysql:mysql-connector-java:8.0.32'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/src/main/java/org/sopt/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/diary/api/DiaryController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
+@RequestMapping("/diaries")
 public class DiaryController {
     private static final int MAX_LENGTH_OF_DIARY = 30;
     private final DiaryService diaryService;
@@ -25,8 +26,8 @@ public class DiaryController {
         this.diaryService = diaryService;
     }
 
-    @PostMapping("/diaries")
-    ResponseEntity<Object> post(@RequestHeader("UserId") Long userId,  @RequestBody DiaryPostRequest diaryPostRequest) {
+    @PostMapping
+    ResponseEntity<Object> post(@RequestHeader("UserId") final Long userId, @RequestBody DiaryPostRequest diaryPostRequest) {
         if (diaryPostRequest.content().length() > MAX_LENGTH_OF_DIARY ){
             throw new GlobalException(FailureStatus.INVALID_PARAMETER);
         }
@@ -34,29 +35,29 @@ public class DiaryController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/diaries")
-    ResponseEntity<DiaryListResponse> get(@RequestHeader("UserId") Long userId) {
+    @GetMapping
+    ResponseEntity<DiaryListResponse> get(@RequestHeader("UserId") final Long userId) {
         return ResponseEntity.ok(
                 new DiaryListResponse(diaryService.getDiaryTen(userId).stream()
                         .map(diary -> new DiaryResponse(diary.getTitle(), diary.getContent())).toList())
         );
     }
 
-    @GetMapping("/diaries/{id}")
-    ResponseEntity<DiaryDetailResponse> getDetailList(@RequestHeader("UserId") Long userId, @PathVariable(name="id") final Long id) {
+    @GetMapping("/{id}")
+    ResponseEntity<DiaryDetailResponse> getDetailList(@RequestHeader("UserId") final Long userId, @PathVariable(name="id") final Long id) {
         DiaryType diaryType = (DiaryType) diaryService.getList(userId, id);
-        DiaryDetailResponse diaryResponse = new DiaryDetailResponse(diaryType.getId(), diaryType.getDateTime(), diaryType.getTitle(), diaryType.getContent());
+        DiaryDetailResponse diaryResponse = new DiaryDetailResponse(diaryType.getId(), diaryType.getDateTime(), diaryType.getTitle(), diaryType.getContent(), diaryType.getScope());
         return ResponseEntity.ok(diaryResponse);
     }
 
-    @DeleteMapping("/diaries/{id}")
-    public ResponseEntity<Void>  delete(@RequestHeader("UserId") Long userId, @PathVariable final Long id){
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void>  delete(@RequestHeader("UserId") final Long userId, @PathVariable(name="id") final Long id){
         diaryService.deleteDiary(userId, id);
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/diaries/{id}")
-    public ResponseEntity<Void> patch(@RequestHeader("UserId") Long userId, @PathVariable("id") final Long id, @RequestBody DiaryPatchRequest diaryPatchRequest) {
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> patch(@RequestHeader("UserId") Long userId, @PathVariable(name="id") final Long id, @RequestBody DiaryPatchRequest diaryPatchRequest) {
         if (diaryPatchRequest.content().length() > MAX_LENGTH_OF_DIARY ){
             throw new GlobalException(FailureStatus.INVALID_PARAMETER);
        }

--- a/src/main/java/org/sopt/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/diary/api/DiaryController.java
@@ -1,8 +1,9 @@
 package org.sopt.diary.api;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.sopt.diary.api.dto.req.DiaryPatchRequest;
 
-import org.sopt.diary.service.Diary;
+import org.sopt.diary.service.DiaryType;
 import org.sopt.diary.api.dto.req.DiaryPostRequest;
 import org.sopt.diary.api.dto.res.DiaryDetailResponse;
 import org.sopt.diary.api.dto.res.DiaryListResponse;
@@ -10,6 +11,7 @@ import org.sopt.diary.api.dto.res.DiaryResponse;
 import org.sopt.diary.exception.FailureStatus;
 import org.sopt.diary.exception.GlobalException;
 import org.sopt.diary.service.DiaryService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,40 +26,41 @@ public class DiaryController {
     }
 
     @PostMapping("/diaries")
-    void post(@RequestBody DiaryPostRequest diaryPostRequest) {
+    ResponseEntity<Object> post(@RequestHeader("UserId") Long userId,  @RequestBody DiaryPostRequest diaryPostRequest) {
         if (diaryPostRequest.content().length() > MAX_LENGTH_OF_DIARY ){
             throw new GlobalException(FailureStatus.INVALID_PARAMETER);
         }
-        diaryService.createDiary(diaryPostRequest);
+        diaryService.createDiary(userId, diaryPostRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @GetMapping("/diaries")
-    ResponseEntity<DiaryListResponse> get() {
+    ResponseEntity<DiaryListResponse> get(@RequestHeader("UserId") Long userId) {
         return ResponseEntity.ok(
-                new DiaryListResponse(diaryService.getDiaryTen().stream()
+                new DiaryListResponse(diaryService.getDiaryTen(userId).stream()
                         .map(diary -> new DiaryResponse(diary.getTitle(), diary.getContent())).toList())
         );
     }
 
     @GetMapping("/diaries/{id}")
-    ResponseEntity<DiaryDetailResponse> getDetailList(@PathVariable final Long id) {
-        Diary diary = (Diary) diaryService.getList(id);
-        DiaryDetailResponse diaryResponse = new DiaryDetailResponse(diary.getId(), diary.getDateTime(), diary.getTitle(), diary.getContent());
+    ResponseEntity<DiaryDetailResponse> getDetailList(@RequestHeader("UserId") Long userId, @PathVariable(name="id") final Long id) {
+        DiaryType diaryType = (DiaryType) diaryService.getList(userId, id);
+        DiaryDetailResponse diaryResponse = new DiaryDetailResponse(diaryType.getId(), diaryType.getDateTime(), diaryType.getTitle(), diaryType.getContent());
         return ResponseEntity.ok(diaryResponse);
     }
 
     @DeleteMapping("/diaries/{id}")
-    public ResponseEntity<Void>  delete(@PathVariable final Long id){
-        diaryService.deleteDiary(id);
+    public ResponseEntity<Void>  delete(@RequestHeader("UserId") Long userId, @PathVariable final Long id){
+        diaryService.deleteDiary(userId, id);
         return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/diaries/{id}")
-    public ResponseEntity<Void> patch(@PathVariable final Long id, @RequestBody DiaryPatchRequest diaryPatchRequest) {
+    public ResponseEntity<Void> patch(@RequestHeader("UserId") Long userId, @PathVariable("id") final Long id, @RequestBody DiaryPatchRequest diaryPatchRequest) {
         if (diaryPatchRequest.content().length() > MAX_LENGTH_OF_DIARY ){
             throw new GlobalException(FailureStatus.INVALID_PARAMETER);
        }
-        diaryService.patchDiary(id, diaryPatchRequest.content());
+        diaryService.patchDiary(userId, id, diaryPatchRequest.content());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/sopt/diary/api/UserController.java
+++ b/src/main/java/org/sopt/diary/api/UserController.java
@@ -1,0 +1,27 @@
+package org.sopt.diary.api;
+
+import jakarta.validation.Valid;
+import org.sopt.diary.api.dto.req.SignUpRequest;
+import org.sopt.diary.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(final UserService userService){
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    private ResponseEntity<?> signUp(@Valid @RequestBody SignUpRequest signUpRequest){
+        userService.createUser(signUpRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/org/sopt/diary/api/UserController.java
+++ b/src/main/java/org/sopt/diary/api/UserController.java
@@ -1,13 +1,18 @@
 package org.sopt.diary.api;
 
 import jakarta.validation.Valid;
+import org.sopt.diary.api.dto.req.LoginRequest;
 import org.sopt.diary.api.dto.req.SignUpRequest;
+import org.sopt.diary.repository.UserEntity;
 import org.sopt.diary.service.UserService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 
 @RestController
@@ -21,7 +26,19 @@ public class UserController {
 
     @PostMapping("/signup")
     private ResponseEntity<?> signUp(@Valid @RequestBody SignUpRequest signUpRequest){
-        userService.createUser(signUpRequest);
-        return ResponseEntity.ok().build();
+         UserEntity user = userService.createUser(signUpRequest);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(user.getId())
+                .toUri());
+        headers.add("UserId", String.valueOf(user.getId()));
+
+        return new ResponseEntity<> (headers, HttpStatus.CREATED);
     }
+
+    @PostMapping("/login")
+    private ResponseEntity<?> login(@Valid @RequestBody LoginRequest loginRequest){
+        return userService.findUser(loginRequest);}
 }

--- a/src/main/java/org/sopt/diary/api/dto/req/DiaryPostRequest.java
+++ b/src/main/java/org/sopt/diary/api/dto/req/DiaryPostRequest.java
@@ -1,4 +1,6 @@
 package org.sopt.diary.api.dto.req;
 
-public record DiaryPostRequest(String title, String content) {
+import org.sopt.diary.constant.DiaryScope;
+
+public record DiaryPostRequest(String title, String content, DiaryScope scope) {
 }

--- a/src/main/java/org/sopt/diary/api/dto/req/LoginRequest.java
+++ b/src/main/java/org/sopt/diary/api/dto/req/LoginRequest.java
@@ -1,0 +1,4 @@
+package org.sopt.diary.api.dto.req;
+
+public record LoginRequest (String email, String password) {
+}

--- a/src/main/java/org/sopt/diary/api/dto/req/SignUpRequest.java
+++ b/src/main/java/org/sopt/diary/api/dto/req/SignUpRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.diary.api.dto.req;
+
+public record SignUpRequest (
+        String name,
+        String nickname, String email, String password){
+}
+

--- a/src/main/java/org/sopt/diary/api/dto/res/DiaryDetailResponse.java
+++ b/src/main/java/org/sopt/diary/api/dto/res/DiaryDetailResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.diary.api.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import org.sopt.diary.constant.DiaryScope;
 
 import java.time.LocalDateTime;
 
@@ -10,12 +11,14 @@ public class DiaryDetailResponse {
     private final LocalDateTime dateTime;
     private final String title;
     private final String content;
+    private final DiaryScope scope;
 
-    public DiaryDetailResponse(long id, LocalDateTime dateTime, String title, String content) {
+    public DiaryDetailResponse(long id, LocalDateTime dateTime, String title, String content, DiaryScope scope) {
         this.id = id;
         this.dateTime = dateTime;
         this.title = title;
         this.content = content;
+        this.scope=scope;
     }
 
     public long getId() {
@@ -32,5 +35,9 @@ public class DiaryDetailResponse {
 
     public String getContent() {
         return content;
+    }
+
+    public DiaryScope getScope() {
+        return scope;
     }
 }

--- a/src/main/java/org/sopt/diary/constant/DiaryScope.java
+++ b/src/main/java/org/sopt/diary/constant/DiaryScope.java
@@ -1,0 +1,12 @@
+package org.sopt.diary.constant;
+
+public enum DiaryScope {
+    PUBLIC("public"),
+    PRIVATE("private");
+
+    private final String value;
+
+    DiaryScope(final String value){
+        this.value=value;
+    }
+}

--- a/src/main/java/org/sopt/diary/exception/FailureCode.java
+++ b/src/main/java/org/sopt/diary/exception/FailureCode.java
@@ -1,8 +1,6 @@
 package org.sopt.diary.exception;
 
-import org.springframework.http.HttpStatus;
-
 public interface FailureCode {
-    HttpStatus getStatus();
+    int getCode();
     String getMessage();
 }

--- a/src/main/java/org/sopt/diary/exception/FailureResponse.java
+++ b/src/main/java/org/sopt/diary/exception/FailureResponse.java
@@ -1,10 +1,14 @@
 package org.sopt.diary.exception;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public record FailureResponse(
-        int status,
-        String message
+        int code,
+        String message,
+        Map<String, Object> data
 ) {
     public static FailureResponse of(FailureCode failureCode) {
-        return new FailureResponse(failureCode.getStatus().value(), failureCode.getMessage());
+        return new FailureResponse(failureCode.getCode(), failureCode.getMessage(), new HashMap<>());
     }
 }

--- a/src/main/java/org/sopt/diary/exception/FailureStatus.java
+++ b/src/main/java/org/sopt/diary/exception/FailureStatus.java
@@ -3,28 +3,39 @@ package org.sopt.diary.exception;
 import org.springframework.http.HttpStatus;
 
 public enum FailureStatus implements FailureCode{
+
     //400 Bad Request 잘못된 요청
-    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "입력 파라미터를 확인해 주세요."),
+    INVALID_PARAMETER(400, "입력 파라미터를 확인해 주세요."),
+    INVALID_EMAIL(40000, "이메일 형식이 유효하지 않습니다."),
+    INVALID_NAME_NICKNAME_LENGTH(40001, "글자수는 최대 10자까지 입력 가능합니다."),
+
+    //401 Unauthorized
+    UNAUTHORIZED(40100, "비밀번호가 잘못되었습니다."),
 
     //404 NOT_FOUND 잘못된 리소스 접근
-    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 다이어리입니다."),
+    DIARY_NOT_FOUND(40400, "존재하지 않는 다이어리입니다."),
+    USER_NOT_FOUND(40400, "존재하지 않는 사용자입니다."),
 
     //405 Method Not Allowed
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메소드입니다."),
+    METHOD_NOT_ALLOWED(40500, "지원하지 않는 HTTP 메소드입니다."),
+
+    //409 CONFLICT
+    CONFLICT_EMAIL(40900, "이메일 중복입니다."),
+    CONFLICT_NICKNAME(40901, "닉네임 중복입니다."),
 
     //500 Internal Server Error
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_ERROR(50000, "서버 내부 오류입니다.");
 
-    private final HttpStatus status;
+    private final int code;
     private final String message;
 
-    FailureStatus(final HttpStatus status, final String message) {
-        this.status = status;
+    FailureStatus(final int code, final String message) {
+        this.code = code;
         this.message = message;
     }
 
-    public HttpStatus getStatus() {
-        return status;
+    public int getCode() {
+        return code;
     }
 
     public String getMessage() {

--- a/src/main/java/org/sopt/diary/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/diary/exception/GlobalExceptionHandler.java
@@ -1,13 +1,42 @@
 package org.sopt.diary.exception;
 
 import org.springframework.http.ResponseEntity;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.sql.SQLIntegrityConstraintViolationException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(GlobalException.class)
-    protected ResponseEntity<FailureResponse> handleException(final GlobalException e){
-        return ResponseEntity.status(e.getFailureCode().getStatus().value()).body(FailureResponse.of(e.getFailureCode()));
+    protected ResponseEntity<FailureResponse> handleGlobalException(final GlobalException e){
+        return ResponseEntity.status(e.getFailureCode().getCode())
+                .body(FailureResponse.of(e.getFailureCode()));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<FailureResponse> hanldeConstraintViolationException(final ConstraintViolationException e){
+        FailureStatus failureStatus = FailureStatus.INVALID_PARAMETER;
+
+        for(var violation : e.getConstraintViolations()){
+            String propertyPath = violation.getPropertyPath().toString();
+
+            if("nickname".equals(propertyPath) || "name".equals(propertyPath)){
+                failureStatus = FailureStatus.INVALID_NAME_NICKNAME_LENGTH ;
+                break;
+            } else if ("email".equals(propertyPath)){
+                failureStatus = FailureStatus.INVALID_EMAIL ;
+                break;
+            }
+        }
+        return ResponseEntity.badRequest().body(FailureResponse.of(failureStatus));
+    }
+
+    @ExceptionHandler(SQLIntegrityConstraintViolationException.class)
+    protected ResponseEntity<FailureResponse> handleSQLIntegrityConstraintViolationException(final SQLIntegrityConstraintViolationException e){
+        FailureStatus failureStatus = FailureStatus.CONFLICT_EMAIL;
+        return ResponseEntity.status(409)
+                .body(FailureResponse.of(failureStatus));
     }
 }

--- a/src/main/java/org/sopt/diary/repository/DiaryEntity.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryEntity.java
@@ -2,35 +2,50 @@ package org.sopt.diary.repository;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
+import org.apache.catalina.User;
 import org.hibernate.annotations.CreationTimestamp;
+import org.sopt.diary.constant.DiaryScope;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "diary_jpa_entity")
 public class DiaryEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long id;
+    @Column(name="diary_id")
+    private Long id;
 
-    @Column
+    @Column(name="diary_title", nullable=false)
+    private String title;
+
+    @Column(name="content", nullable = false)
+    private String content;
+
+    @Column(name="createdAt")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @JsonFormat(shape= JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone="Asia/Seoul")
     @CreationTimestamp
-    public LocalDateTime dateTime;
+    private LocalDateTime dateTime;
 
-    @Column(name="title")
-    public String title;
-
-    @Column(name="content")
-    public String content;
+    @Column
+    @Enumerated(EnumType.STRING)
+    private DiaryScope scope;
 
     public DiaryEntity(){
     }
 
-    public DiaryEntity(String title, String content){
+    public DiaryEntity(UserEntity user, String title, String content, DiaryScope scope){
+        this.user = user;
         this.title= title;
         this.content=content;
+        this.scope=scope;
     }
 
     public long getId() {
@@ -49,7 +64,21 @@ public class DiaryEntity {
         return this.content;
     }
 
+    public DiaryScope getScope() { return this.scope; }
+
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     public void setContent(String content) {
         this.content=content;
     }
+
+    public void setScope(DiaryScope scope) { this.scope = scope; }
+
+    public void setUser(UserEntity user) {
+        this.user = user;
+    }
+
 }

--- a/src/main/java/org/sopt/diary/repository/DiaryEntity.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryEntity.java
@@ -66,6 +66,8 @@ public class DiaryEntity {
 
     public DiaryScope getScope() { return this.scope; }
 
+    public UserEntity getUser() {return this.user;}
+
 
     public void setTitle(String title) {
         this.title = title;

--- a/src/main/java/org/sopt/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryRepository.java
@@ -3,8 +3,10 @@ package org.sopt.diary.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Optional;
+
 @Component
 public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
-    //findAll, save 등의 행위가 정의되어 있음
-    //실제 구현체들은 jpa가 알아서 (springboot가 해주는 작업)
+    List<DiaryEntity> findByUserId(Long userId);
 }

--- a/src/main/java/org/sopt/diary/repository/UserEntity.java
+++ b/src/main/java/org/sopt/diary/repository/UserEntity.java
@@ -1,0 +1,61 @@
+package org.sopt.diary.repository;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Table(name = "user")
+public class UserEntity {
+    public static final int MAX_INPUT_LENGTH = 10;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="id", nullable = false)
+    private Long id;
+
+    @Size(max = MAX_INPUT_LENGTH, message = "최대 10글자까지 입력 가능합니다.")
+    @Column(name="name", nullable = false)
+    private String name;
+
+    @Size(max = MAX_INPUT_LENGTH, message = "최대 10글자까지 입력 가능합니다.")
+    @Column(name="nickname", nullable = false)
+    private String nickname;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Column(name="email", nullable = false)
+    private String email;
+
+    @Column(name="password", nullable = false)
+    private String password;
+
+    public UserEntity(String name, String nickname, String email, String password) {
+        this.name=name;
+        this.nickname=nickname;
+        this.email=email;
+        this.password=password;
+    }
+
+    public UserEntity(){
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName(){
+        return name;
+    }
+
+    public String getNickname(){
+        return nickname;
+    }
+
+    public String getEmail(){
+        return email;
+    }
+
+    public String getPassword(){
+        return password;
+    }
+}

--- a/src/main/java/org/sopt/diary/repository/UserEntity.java
+++ b/src/main/java/org/sopt/diary/repository/UserEntity.java
@@ -5,25 +5,25 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users")
 public class UserEntity {
     public static final int MAX_INPUT_LENGTH = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="id", nullable = false)
+    @Column(name="user_id", nullable = false)
     private Long id;
 
-    @Size(max = MAX_INPUT_LENGTH, message = "최대 10글자까지 입력 가능합니다.")
-    @Column(name="name", nullable = false)
+    @Column(name="name", nullable = false, length = 10)
+//    @Size(max = MAX_INPUT_LENGTH, message = "최대 10글자까지 입력 가능합니다.")
     private String name;
 
-    @Size(max = MAX_INPUT_LENGTH, message = "최대 10글자까지 입력 가능합니다.")
-    @Column(name="nickname", nullable = false)
+//    @Size(max = MAX_INPUT_LENGTH, message = "최대 10글자까지 입력 가능합니다.")
+    @Column(name="nickname", nullable = false, length = 10)
     private String nickname;
 
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    @Column(name="email", nullable = false)
+//    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Column(name="email", nullable = false, unique = true)
     private String email;
 
     @Column(name="password", nullable = false)

--- a/src/main/java/org/sopt/diary/repository/UserRepository.java
+++ b/src/main/java/org/sopt/diary/repository/UserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    UserEntity findByEmail(String email);
 }

--- a/src/main/java/org/sopt/diary/repository/UserRepository.java
+++ b/src/main/java/org/sopt/diary/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.diary.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+}

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -3,6 +3,7 @@ package org.sopt.diary.service;
 import java.util.List;
 
 import org.sopt.diary.api.dto.req.DiaryPostRequest;
+import org.sopt.diary.constant.DiaryScope;
 import org.sopt.diary.exception.FailureStatus;
 import org.sopt.diary.exception.GlobalException;
 import org.sopt.diary.repository.DiaryEntity;
@@ -35,8 +36,9 @@ public class DiaryService {
     }
 
     public List<DiaryEntity> getDiaryTen(Long userId){
-        List<DiaryEntity> diaries = diaryRepository.findByUserId(userId);
+        List<DiaryEntity> diaries = diaryRepository.findAll();
         return diaries.stream()
+                .filter(diary -> diary.getUser().getId().equals(userId) || diary.getScope() == DiaryScope.PUBLIC)
                 .sorted((diaryEntity1, diaryEntity2)-> diaryEntity2.getDateTime().compareTo(diaryEntity1.getDateTime()))
                 .limit(MAX_LIST_OF_DIARY)
                 .toList();

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -7,48 +7,62 @@ import org.sopt.diary.exception.FailureStatus;
 import org.sopt.diary.exception.GlobalException;
 import org.sopt.diary.repository.DiaryEntity;
 import org.sopt.diary.repository.DiaryRepository;
+import org.sopt.diary.repository.UserEntity;
+import org.sopt.diary.repository.UserRepository;
 import org.springframework.stereotype.Component;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Component
 public class DiaryService {
     private static final int MAX_LIST_OF_DIARY = 10;
 
     private final DiaryRepository diaryRepository;
-
-    public DiaryService (DiaryRepository diaryRepository){
+    private final UserRepository userRepository;
+    public DiaryService (DiaryRepository diaryRepository, UserRepository userRepository){
         this.diaryRepository =  diaryRepository;
+        this.userRepository = userRepository;
     }
 
-    public void createDiary(@RequestBody DiaryPostRequest diaryPostRequest) {
-        diaryRepository.save(new DiaryEntity(diaryPostRequest.title(), diaryPostRequest.content()));
+    public void createDiary(Long userId, DiaryPostRequest diaryPostRequest) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(FailureStatus.USER_NOT_FOUND));
+        DiaryEntity diary = new DiaryEntity();
+        diary.setUser(user);
+        diary.setTitle(diaryPostRequest.title());
+        diary.setContent(diaryPostRequest.content());
+        diary.setScope(diaryPostRequest.scope());
+
+        diaryRepository.save(diary);
     }
 
-    public List<DiaryEntity> getDiaryTen(){
-        List<DiaryEntity> diaries = diaryRepository.findAll();
+    public List<DiaryEntity> getDiaryTen(Long userId){
+        List<DiaryEntity> diaries = diaryRepository.findByUserId(userId);
         return diaries.stream()
-                .sorted((diary1, diary2)->diary2.getDateTime().compareTo(diary1.getDateTime()))
+                .sorted((diaryEntity1, diaryEntity2)-> diaryEntity2.getDateTime().compareTo(diaryEntity1.getDateTime()))
                 .limit(MAX_LIST_OF_DIARY)
                 .toList();
     }
 
-    public Diary getList(long id) {
-        DiaryEntity diary = diaryRepository.findById(id)
-                .orElseThrow(() -> new GlobalException(FailureStatus.DIARY_NOT_FOUND));
-        return new Diary(diary.getId(), diary.getDateTime(), diary.getTitle(), diary.getContent());
+    public DiaryType getList(Long userId, Long id) {
+        DiaryEntity diaryEntity = findDiary(userId, id);
+        return new DiaryType(diaryEntity.getId(), diaryEntity.getDateTime(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getScope());
     }
 
-
-    public void deleteDiary(long id){
-        DiaryEntity diary=diaryRepository.findById(id)
-                .orElseThrow(() -> new GlobalException(FailureStatus.DIARY_NOT_FOUND));
-        diaryRepository.delete(diary);
+    public void deleteDiary(Long userId, Long id){
+        DiaryEntity diaryEntity = findDiary(userId, id);
+        diaryRepository.delete(diaryEntity);
     }
 
-    public void patchDiary(long id, String content){
-        DiaryEntity diary=diaryRepository.findById(id)
+    public void patchDiary(Long userId, Long id, String content){
+        DiaryEntity diaryEntity = findDiary(userId, id);
+        diaryEntity.setContent(content);
+        diaryRepository.save(diaryEntity);
+    }
+
+    private DiaryEntity findDiary(Long userId, Long id) {
+        List<DiaryEntity> diaries = diaryRepository.findByUserId(userId);
+        return diaries.stream()
+                .filter(diary -> diary.getId() == id)
+                .findFirst()
                 .orElseThrow(() -> new GlobalException(FailureStatus.DIARY_NOT_FOUND));
-        diary.setContent(content);
-        diaryRepository.save(diary);
     }
 }

--- a/src/main/java/org/sopt/diary/service/DiaryType.java
+++ b/src/main/java/org/sopt/diary/service/DiaryType.java
@@ -1,6 +1,5 @@
 package org.sopt.diary.service;
 
-/*import org.sopt.diary.constant.Scope;*/
 import org.sopt.diary.constant.DiaryScope;
 
 import java.time.LocalDateTime;
@@ -11,14 +10,14 @@ public class DiaryType {
     private final LocalDateTime dateTime;
     private final String title;
     private final String content;
- /*   private final Scope scope;
-*/
-    public DiaryType(long id, LocalDateTime dateTime, String title, String content,/*, Scope scope*/DiaryScope scope){
+    private final DiaryScope scope;
+
+    public DiaryType(long id, LocalDateTime dateTime, String title, String content, DiaryScope scope){
         this.id = id;
         this.dateTime= dateTime;
         this.title = title;
         this.content = content;
-/*        this.scope = scope;*/
+        this.scope = scope;
     }
 
     public long getId(){
@@ -36,5 +35,7 @@ public class DiaryType {
     public String getContent(){
         return  content;
     }
+
+    public DiaryScope getScope() {return scope;}
 }
 

--- a/src/main/java/org/sopt/diary/service/DiaryType.java
+++ b/src/main/java/org/sopt/diary/service/DiaryType.java
@@ -1,18 +1,24 @@
 package org.sopt.diary.service;
+
+/*import org.sopt.diary.constant.Scope;*/
+import org.sopt.diary.constant.DiaryScope;
+
 import java.time.LocalDateTime;
 
-public class Diary {
+public class DiaryType {
 
     private final long id;
     private final LocalDateTime dateTime;
     private final String title;
     private final String content;
-
-    public Diary(long id, LocalDateTime dateTime, String title, String content){
+ /*   private final Scope scope;
+*/
+    public DiaryType(long id, LocalDateTime dateTime, String title, String content,/*, Scope scope*/DiaryScope scope){
         this.id = id;
         this.dateTime= dateTime;
         this.title = title;
         this.content = content;
+/*        this.scope = scope;*/
     }
 
     public long getId(){

--- a/src/main/java/org/sopt/diary/service/UserService.java
+++ b/src/main/java/org/sopt/diary/service/UserService.java
@@ -1,0 +1,22 @@
+package org.sopt.diary.service;
+
+import jakarta.validation.Valid;
+import org.sopt.diary.api.dto.req.SignUpRequest;
+import org.sopt.diary.repository.UserEntity;
+import org.sopt.diary.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public void createUser(@Valid SignUpRequest signUpRequest){
+        userRepository.save(new UserEntity(signUpRequest.name(), signUpRequest.nickname().replaceAll(" ", ""), signUpRequest.email(), signUpRequest.password()));
+    }
+}
+

--- a/src/main/java/org/sopt/diary/service/UserService.java
+++ b/src/main/java/org/sopt/diary/service/UserService.java
@@ -1,10 +1,16 @@
 package org.sopt.diary.service;
 
 import jakarta.validation.Valid;
+import org.sopt.diary.api.dto.req.LoginRequest;
 import org.sopt.diary.api.dto.req.SignUpRequest;
+import org.sopt.diary.exception.FailureResponse;
+import org.sopt.diary.exception.FailureStatus;
 import org.sopt.diary.repository.UserEntity;
 import org.sopt.diary.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 public class UserService {
@@ -15,8 +21,23 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public void createUser(@Valid SignUpRequest signUpRequest){
-        userRepository.save(new UserEntity(signUpRequest.name(), signUpRequest.nickname().replaceAll(" ", ""), signUpRequest.email(), signUpRequest.password()));
+    public UserEntity createUser(@Valid SignUpRequest signUpRequest){
+        UserEntity user = (new UserEntity(signUpRequest.name(), signUpRequest.nickname().replaceAll(" ", ""), signUpRequest.email(), signUpRequest.password()));
+        return userRepository.save(user);
+    }
+
+    public ResponseEntity<?> findUser(@Valid LoginRequest loginRequest) {
+        UserEntity user = userRepository.findByEmail(loginRequest.email());
+        if (user == null) {
+            FailureStatus failureStatus = FailureStatus.INVALID_EMAIL;
+            return ResponseEntity.status(400).body(FailureResponse.of(failureStatus));
+        } else{
+            if(!Objects.equals(user.getPassword(), loginRequest.password())){
+                FailureStatus failureStatus = FailureStatus.UNAUTHORIZED;
+                return ResponseEntity.status(401).body(FailureResponse.of(failureStatus));
+            } else{
+                return ResponseEntity.ok(user);}
+        }
     }
 }
 

--- a/src/main/java/org/sopt/week3/Controller.java
+++ b/src/main/java/org/sopt/week3/Controller.java
@@ -1,0 +1,33 @@
+package org.sopt.week3;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class Controller {
+    private final SoptMemberRepository soptMemberRepository;
+
+    public Controller(SoptMemberRepository soptMemberRepository){
+        this.soptMemberRepository = soptMemberRepository;
+    }
+    @PostMapping("/members")
+    void postMember(){
+        soptMemberRepository.save(
+                new SoptMemberEntity("상아", 19)
+        );
+    }
+
+    @GetMapping("/members")
+    ResponseEntity<String> getMembers(){
+        List<SoptMemberEntity> all = soptMemberRepository.findAll();
+
+        return ResponseEntity.ok(
+                all.stream().findFirst().get().toString()
+        );
+    }
+}
+

--- a/src/main/java/org/sopt/week3/DiaryApplication.java
+++ b/src/main/java/org/sopt/week3/DiaryApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class DiaryApplication {
-    public static void main(String[] args){
+    public static void main(String[] args) {
         SpringApplication.run(DiaryApplication.class, args);
     }
 }

--- a/src/main/java/org/sopt/week3/DiaryApplication.java
+++ b/src/main/java/org/sopt/week3/DiaryApplication.java
@@ -1,0 +1,11 @@
+package org.sopt.week3;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DiaryApplication {
+    public static void main(String[] args){
+        SpringApplication.run(DiaryApplication.class, args);
+    }
+}

--- a/src/main/java/org/sopt/week3/SoptMemberEntity.java
+++ b/src/main/java/org/sopt/week3/SoptMemberEntity.java
@@ -1,0 +1,31 @@
+package org.sopt.week3;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "sopt_member")
+public class SoptMemberEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "age", nullable = false)
+    private int age;
+
+    public SoptMemberEntity(String name, int age){
+        this.name=name;
+        this.age=age;
+    }
+
+    public SoptMemberEntity(){
+    }
+
+    @Override
+    public String toString(){
+        return this.name;
+    }
+}

--- a/src/main/java/org/sopt/week3/SoptMemberRepository.java
+++ b/src/main/java/org/sopt/week3/SoptMemberRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.week3;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SoptMemberRepository extends JpaRepository<SoptMemberEntity, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://db-2vfrih-kr.vpc-pub-cdb.ntruss.com:3306/team8
+    username: sopt-35-root
+    password: 1q2w3e4r12!@
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: none
+      dialect: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      format_sql: true
+      show_sql: true


### PR DESCRIPTION
## 📍관련 이슈
closed #8 

## 📍과제 구현
- [x] 로그인 기능
- [x] 회원가입 기능
- [x] 기존 다이어리 테이블과 유저 테이블 연결

## 📍구현 내용

### 회원가입
```java
    @PostMapping("/signup")
    private ResponseEntity<?> signUp(@Valid @RequestBody SignUpRequest signUpRequest){
        UserEntity user = userService.createUser(signUpRequest);
        HttpHeaders headers = new HttpHeaders();
        headers.setLocation(ServletUriComponentsBuilder
                .fromCurrentRequest()
                .path("/{id}")
                .buildAndExpand(user.getId())
                .toUri());
        headers.add("UserId", String.valueOf(user.getId()));

        return new ResponseEntity<> (headers, HttpStatus.CREATED);
    }
```

### 로그인
```java
    @PostMapping("/login")
    private ResponseEntity<?> login(@Valid @RequestBody LoginRequest loginRequest){
        return userService.findUser(loginRequest);
```

## 📍새로 배운 점
- `HttpHeaders` 를 사용해 헤더 정보 내보내고, `@RequestHeader` 를 사용해 헤더 정보를 함께 받아올 수 있다 
- `@ManyToOne`, `@JoinColumn` 어노테이션을 사용해 테이블 간 PK-FK 연결을 생성할 수 있음 
- `application.yml`에서 hibernate: ddl-auto: none 속성을 통해 데이터 베이스가 꼬이는 것을 방지할 수 있으나, 최초 생성 시 create 로 입력해  entity에 맞게 테이블을 생성해도 됨

## 📍궁금한 점
- 전역 처리 시 파일간 역할을 어느 정도까지 분리하는 게 좋을지 고민됨...